### PR TITLE
Revert "Add github commit name"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ inputs:
     description: "Regular expression to check commit message subject"
     required: false
     default: |
-      ^(((?!Merge)[A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [\- ._,()A-Za-z0-9]*[)A-Za-z0-9]|Merge[^\n]*$
+      ^(([A-Z]{2,10}-[0-9]+)(, [A-Z]{2,10}-[0-9]+)*: )?\b(?!Made)(?![A-Za-z]*(ing|ung|ang|ed|id|[^s]s)\b)[A-Z][a-z]*\b [/\- ._,()A-Za-z0-9]*[)A-Za-z0-9]$
   re-pull-request-title:
     description: "Regular expression to check pull request title"
     required: false


### PR DESCRIPTION
Merge commits should not be used, so reverting this change.